### PR TITLE
Add link to ERRORCODES.md to the `error` description

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -52,7 +52,7 @@ The error packet is sent by the server if something went wrong.
 **Arguments:**  
 | # | Type | Description |
 |---|--------|--------------|
-| 1 | String | The error |
+| 1 | String | The error according to [ERRORCODES.md](ERRORCODES.md) |
 
 **Example:** `error|INVALID_USERNAME`
 


### PR DESCRIPTION
I added a link to ERRORCODES.md to the description of the `error` packet.